### PR TITLE
v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## 1.14.0
+### Changes
+- When you have a page with a single select question block, it will no longer automatically close after selection.
+- When you have a carousel with a single select question block, it will no longer automatically push the next page after selection.
+- The pause function will now also prevent screens from push notifications from showing. When you pause the SDK and a user opens a push, it will only show the screen after you've called resume.
+- When a user selects a button with a deeplink, we'll close our actvity for you.
+
+### Added
+- You can now configure if a question requires a response or not.
+
+### Fixed
+- We've improved the layouts for our visual screens to hug most of the time, and flex when it would look better.
+- When closing a page via a link, the animation has been corrected.
+
 ## 1.13.1
 ### Fixed
 - Modals with small content will now self-size correctly.

--- a/samples/unflow-compose/app/build.gradle.kts
+++ b/samples/unflow-compose/app/build.gradle.kts
@@ -49,7 +49,7 @@ android {
 }
 
 dependencies {
-    implementation("com.unflow:unflow-ui:1.13.1")
+    implementation("com.unflow:unflow-ui:1.14.0")
 
     implementation("androidx.compose.ui:ui:${rootProject.extra["compose_version"]}")
     implementation("androidx.compose.material:material:${rootProject.extra["compose_version"]}")

--- a/samples/unflow-java/app/build.gradle
+++ b/samples/unflow-java/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.unflow:unflow-ui:1.13.1'
+    implementation 'com.unflow:unflow-ui:1.14.0'
 
     implementation 'com.github.bumptech.glide:glide:4.13.2'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.13.2'

--- a/samples/unflow-sample/app/build.gradle
+++ b/samples/unflow-sample/app/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.unflow:unflow-ui:1.13.1'
+    implementation 'com.unflow:unflow-ui:1.14.0'
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'


### PR DESCRIPTION
### Changes
- When you have a page with a single select question block, it will no longer automatically close after selection.
- When you have a carousel with a single select question block, it will no longer automatically push the next page after selection.
- The pause function will now also prevent screens from push notifications from showing. When you pause the SDK and a user opens a push, it will only show the screen after you've called resume.
- When a user selects a button with a deeplink, we'll close our actvity for you.

### Added
- You can now configure if a question requires a response or not.

### Fixed
- We've improved the layouts for our visual screens to hug most of the time, and flex when it would look better.
- When closing a page via a link, the animation has been corrected.