### PR TITLE
v1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.14.1
+### Changes
+- Article images are now 4/3 always, regardless of the content of the image
+
 ## 1.14.0
 ### Changes
 - When you have a page with a single select question block, it will no longer automatically close after selection.

--- a/samples/unflow-compose/app/build.gradle.kts
+++ b/samples/unflow-compose/app/build.gradle.kts
@@ -49,7 +49,7 @@ android {
 }
 
 dependencies {
-    implementation("com.unflow:unflow-ui:1.14.0")
+    implementation("com.unflow:unflow-ui:1.14.1")
 
     implementation("androidx.compose.ui:ui:${rootProject.extra["compose_version"]}")
     implementation("androidx.compose.material:material:${rootProject.extra["compose_version"]}")

--- a/samples/unflow-java/app/build.gradle
+++ b/samples/unflow-java/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.unflow:unflow-ui:1.14.0'
+    implementation 'com.unflow:unflow-ui:1.14.1'
 
     implementation 'com.github.bumptech.glide:glide:4.13.2'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.13.2'

--- a/samples/unflow-sample/app/build.gradle
+++ b/samples/unflow-sample/app/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.unflow:unflow-ui:1.14.0'
+    implementation 'com.unflow:unflow-ui:1.14.1'
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'


### PR DESCRIPTION
This SDK update makes a change to how images are sized on our articles. We used to try to squish the image around to make sure that it looks good, but we realised that it's actually better to just be consistent. 

With that in mind, we've now switched all of our articles screens to use a 4:3 image up top, which will be sized based on the width of the device. Your image will be center cropped.

For a helping hand with visualising this, please use our [Figma Template](https://www.figma.com/file/0AKDDiE9CitSz7BIvoKAZp/Unflow-Image-Editor?node-id=909%3A75&t=ikGwfZjHPOHuyJCU-1).

Your existing articles should generally look better out of the box, with a much closer match to the dashboard, but we'd reccomend giving them a once over to make sure they look great.

## Changes
- Article images are now 4/3 always, regardless of the content of the image