### PR TITLE
v1.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.15.1
+### Fixes
+- Close actions will now behave as expected in Flows.
+- Screens with their completion actions empty will now allow normal logic to take place.
+- Stops a bug where blocks could sometimes be re-ordered.
+- When you use the `pause` function, and provide a push notification, it will now only show the content when you call resume.
+
 ## 1.15.0
 ### Added
 - You can use `clearUserSession` to remove the users attributes, and clear their ID.

--- a/samples/unflow-compose/app/build.gradle.kts
+++ b/samples/unflow-compose/app/build.gradle.kts
@@ -49,7 +49,7 @@ android {
 }
 
 dependencies {
-    implementation("com.unflow:unflow-ui:1.15.0")
+    implementation("com.unflow:unflow-ui:1.15.1")
 
     implementation("androidx.compose.ui:ui:${rootProject.extra["compose_version"]}")
     implementation("androidx.compose.material:material:${rootProject.extra["compose_version"]}")

--- a/samples/unflow-java/app/build.gradle
+++ b/samples/unflow-java/app/build.gradle
@@ -30,7 +30,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.unflow:unflow-ui:1.15.0'
+    implementation 'com.unflow:unflow-ui:1.15.1'
 
     implementation 'com.github.bumptech.glide:glide:4.13.2'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.13.2'

--- a/samples/unflow-sample/app/build.gradle
+++ b/samples/unflow-sample/app/build.gradle
@@ -32,7 +32,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.unflow:unflow-ui:1.15.0'
+    implementation 'com.unflow:unflow-ui:1.15.1'
 
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'


### PR DESCRIPTION
### Fixes
- Close actions will now behave as expected in Flows.
- Screens with their completion actions empty will now allow normal logic to take place.
- Stops a bug where blocks could sometimes be re-ordered.
- When you use the `pause` function, and provide a push notification, it will now only show the content when you call resume.